### PR TITLE
Add benchmark tracking.

### DIFF
--- a/.github/workflows/publish-sphere.benchmark-dotnet.yml
+++ b/.github/workflows/publish-sphere.benchmark-dotnet.yml
@@ -11,7 +11,7 @@ env:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
   DOTNET_NOLOGO: true
   Prefix: 'sphere.benchmarkdotnet'
-  Project: 'source/Atmoos.Sphere/Atmoos.Sphere.BenchmarkDotNet.csproj'
+  Project: 'source/Atmoos.Sphere.BenchmarkDotNet/Atmoos.Sphere.BenchmarkDotNet.csproj'
   DotNetVersion: 8.0.x
   NugetKey: ${{ secrets.CREATENEWNUGETPACKAGE }}
 

--- a/.github/workflows/publish-sphere.benchmark-dotnet.yml
+++ b/.github/workflows/publish-sphere.benchmark-dotnet.yml
@@ -1,0 +1,36 @@
+name: Publish Atmoos.Sphere.BenchmarkDotNet
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [ "main" ]
+    paths: 
+      - '**/Atmoos.Sphere.BenchmarkDotNet.csproj'
+
+env:
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
+  DOTNET_NOLOGO: true
+  Prefix: 'sphere.benchmarkdotnet'
+  Project: 'source/Atmoos.Sphere/Atmoos.Sphere.BenchmarkDotNet.csproj'
+  DotNetVersion: 8.0.x
+  NugetKey: ${{ secrets.CREATENEWNUGETPACKAGE }}
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ env.DotNetVersion }}
+      - name: Publish
+        uses: tedd/publish-nuget-neo@v1
+        with:
+          NUGET_KEY: ${{env.NugetKey}}
+          PROJECT_FILE_PATH: ${{env.Project}}
+          TAG_COMMIT: true
+          TAG_FORMAT: ${{env.Prefix}}/v*

--- a/source/Atmoos.Sphere.Benchmark/Async/OrderByCompletionBenchmark.cs
+++ b/source/Atmoos.Sphere.Benchmark/Async/OrderByCompletionBenchmark.cs
@@ -60,25 +60,25 @@ BenchmarkDotNet v0.13.12, Arch Linux
 Intel Core i7-8565U CPU 1.80GHz (Whiskey Lake), 1 CPU, 8 logical and 4 physical cores
 .NET SDK 8.0.104
   [Host]     : .NET 8.0.4 (8.0.424.16909), X64 RyuJIT AVX2
-  Job-WZFBTT : .NET 8.0.4 (8.0.424.16909), X64 RyuJIT AVX2
+  Job-UFLBFX : .NET 8.0.4 (8.0.424.16909), X64 RyuJIT AVX2
 
 InvocationCount=1  UnrollFactor=1  
 
 | Method                  | Count | Mean       | Error   | Ratio | Allocated  | Alloc Ratio |
 |------------------------ |------ |-----------:|--------:|------:|-----------:|------------:|
-| Unordered               | 128   |   257.0 ms | 1.77 ms |  1.00 |    1.33 KB |        0.04 |
-| OrderedByCompletion     | 128   |   257.9 ms | 1.32 ms |  1.00 |   31.51 KB |        1.00 |
-| NaiveCompletionOrdering | 128   |   258.2 ms | 0.71 ms |  1.00 |  116.94 KB |        3.71 |
+| Unordered               | 128   |   257.5 ms | 1.44 ms |  1.00 |    1.33 KB |        0.04 |
+| OrderedByCompletion     | 128   |   257.5 ms | 1.40 ms |  1.00 |   32.29 KB |        1.00 |
+| NaiveCompletionOrdering | 128   |   257.3 ms | 1.26 ms |  1.00 |  115.79 KB |        3.59 |
 |                         |       |            |         |       |            |             |
-| Unordered               | 256   |   514.0 ms | 1.33 ms |  1.00 |    1.33 KB |        0.02 |
-| OrderedByCompletion     | 256   |   514.4 ms | 0.91 ms |  1.00 |   61.76 KB |        1.00 |
-| NaiveCompletionOrdering | 256   |   514.3 ms | 0.77 ms |  1.00 |  343.47 KB |        5.56 |
+| Unordered               | 256   |   513.9 ms | 0.68 ms |  1.00 |    1.33 KB |        0.02 |
+| OrderedByCompletion     | 256   |   513.5 ms | 1.27 ms |  1.00 |   61.76 KB |        1.00 |
+| NaiveCompletionOrdering | 256   |   513.4 ms | 1.26 ms |  1.00 |  344.52 KB |        5.58 |
 |                         |       |            |         |       |            |             |
-| Unordered               | 512   | 1,023.7 ms | 0.80 ms |  1.00 |    1.33 KB |        0.01 |
-| OrderedByCompletion     | 512   | 1,023.8 ms | 0.87 ms |  1.00 |  121.38 KB |        1.00 |
-| NaiveCompletionOrdering | 512   | 1,023.7 ms | 1.06 ms |  1.00 | 1198.01 KB |        9.87 |
+| Unordered               | 512   | 1,022.2 ms | 1.76 ms |  1.00 |    1.33 KB |        0.01 |
+| OrderedByCompletion     | 512   | 1,023.0 ms | 1.04 ms |  1.00 |  121.63 KB |        1.00 |
+| NaiveCompletionOrdering | 512   | 1,023.6 ms | 1.07 ms |  1.00 | 1231.64 KB |       10.13 |
 |                         |       |            |         |       |            |             |
-| Unordered               | 1024  | 2,046.3 ms | 1.84 ms |  1.00 |    1.33 KB |       0.006 |
-| OrderedByCompletion     | 1024  | 2,046.4 ms | 1.39 ms |  1.00 |  241.38 KB |       1.000 |
-| NaiveCompletionOrdering | 1024  | 2,044.8 ms | 4.04 ms |  1.00 | 4461.77 KB |      18.484 |
+| Unordered               | 1024  | 2,046.7 ms | 1.81 ms |  1.00 |    1.33 KB |       0.005 |
+| OrderedByCompletion     | 1024  | 2,045.5 ms | 3.22 ms |  1.00 |  241.63 KB |       1.000 |
+| NaiveCompletionOrdering | 1024  | 2,047.0 ms | 1.88 ms |  1.00 | 4508.52 KB |      18.659 |
 /* End */

--- a/source/Atmoos.Sphere.Benchmark/Async/OrderByCompletionBenchmark.cs
+++ b/source/Atmoos.Sphere.Benchmark/Async/OrderByCompletionBenchmark.cs
@@ -1,4 +1,4 @@
-﻿using Atmoos.Sphere.Async;
+using Atmoos.Sphere.Async;
 using BenchmarkDotNet.Attributes;
 
 namespace Atmoos.Sphere.Benchmark;
@@ -54,32 +54,31 @@ public class OrderByCompletionBenchmark
     }
 }
 
-/*
-// * Summary *
+/* Summary *
 
 BenchmarkDotNet v0.13.12, Arch Linux
 Intel Core i7-8565U CPU 1.80GHz (Whiskey Lake), 1 CPU, 8 logical and 4 physical cores
 .NET SDK 8.0.104
   [Host]     : .NET 8.0.4 (8.0.424.16909), X64 RyuJIT AVX2
-  Job-BYDFQV : .NET 8.0.4 (8.0.424.16909), X64 RyuJIT AVX2
+  Job-WZFBTT : .NET 8.0.4 (8.0.424.16909), X64 RyuJIT AVX2
 
 InvocationCount=1  UnrollFactor=1  
 
 | Method                  | Count | Mean       | Error   | Ratio | Allocated  | Alloc Ratio |
 |------------------------ |------ |-----------:|--------:|------:|-----------:|------------:|
-| Unordered               | 128   |   257.2 ms | 1.70 ms |  1.00 |    1.33 KB |        0.04 |
-| OrderedByCompletion     | 128   |   257.3 ms | 1.43 ms |  1.00 |   31.76 KB |        1.00 |
-| NaiveCompletionOrdering | 128   |   257.5 ms | 1.33 ms |  1.00 |  117.54 KB |        3.70 |
+| Unordered               | 128   |   257.0 ms | 1.77 ms |  1.00 |    1.33 KB |        0.04 |
+| OrderedByCompletion     | 128   |   257.9 ms | 1.32 ms |  1.00 |   31.51 KB |        1.00 |
+| NaiveCompletionOrdering | 128   |   258.2 ms | 0.71 ms |  1.00 |  116.94 KB |        3.71 |
 |                         |       |            |         |       |            |             |
-| Unordered               | 256   |   514.0 ms | 0.76 ms |  1.00 |    1.33 KB |        0.02 |
-| OrderedByCompletion     | 256   |   513.9 ms | 1.09 ms |  1.00 |   61.38 KB |        1.00 |
-| NaiveCompletionOrdering | 256   |   514.2 ms | 1.16 ms |  1.00 |  346.22 KB |        5.64 |
+| Unordered               | 256   |   514.0 ms | 1.33 ms |  1.00 |    1.33 KB |        0.02 |
+| OrderedByCompletion     | 256   |   514.4 ms | 0.91 ms |  1.00 |   61.76 KB |        1.00 |
+| NaiveCompletionOrdering | 256   |   514.3 ms | 0.77 ms |  1.00 |  343.47 KB |        5.56 |
 |                         |       |            |         |       |            |             |
-| Unordered               | 512   | 1,023.0 ms | 1.14 ms |  1.00 |    1.33 KB |        0.01 |
-| OrderedByCompletion     | 512   | 1,023.3 ms | 1.97 ms |  1.00 |  121.38 KB |        1.00 |
-| NaiveCompletionOrdering | 512   | 1,023.6 ms | 0.65 ms |  1.00 | 1199.12 KB |        9.88 |
+| Unordered               | 512   | 1,023.7 ms | 0.80 ms |  1.00 |    1.33 KB |        0.01 |
+| OrderedByCompletion     | 512   | 1,023.8 ms | 0.87 ms |  1.00 |  121.38 KB |        1.00 |
+| NaiveCompletionOrdering | 512   | 1,023.7 ms | 1.06 ms |  1.00 | 1198.01 KB |        9.87 |
 |                         |       |            |         |       |            |             |
-| Unordered               | 1024  | 2,046.7 ms | 1.65 ms |  1.00 |    1.33 KB |       0.006 |
-| OrderedByCompletion     | 1024  | 2,045.5 ms | 2.76 ms |  1.00 |  241.38 KB |       1.000 |
-| NaiveCompletionOrdering | 1024  | 2,046.7 ms | 2.14 ms |  1.00 | 4486.54 KB |      18.587 |
-*/
+| Unordered               | 1024  | 2,046.3 ms | 1.84 ms |  1.00 |    1.33 KB |       0.006 |
+| OrderedByCompletion     | 1024  | 2,046.4 ms | 1.39 ms |  1.00 |  241.38 KB |       1.000 |
+| NaiveCompletionOrdering | 1024  | 2,044.8 ms | 4.04 ms |  1.00 | 4461.77 KB |      18.484 |
+/* End */

--- a/source/Atmoos.Sphere.Benchmark/Atmoos.Sphere.Benchmark.csproj
+++ b/source/Atmoos.Sphere.Benchmark/Atmoos.Sphere.Benchmark.csproj
@@ -19,12 +19,12 @@
   
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.13.12" />
-    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows"
-                      Version="0.13.12"
-                      Condition="'$(OS)' == 'Windows_NT'" />
+    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.13.12" Condition="'$(OS)' == 'Windows_NT'" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Atmoos.Sphere\Atmoos.Sphere.csproj" />
+    <ProjectReference Include="..\Atmoos.Sphere.BenchmarkDotNet\Atmoos.Sphere.BenchmarkDotNet.csproj" />
   </ItemGroup>
+  
 </Project>

--- a/source/Atmoos.Sphere.Benchmark/Program.cs
+++ b/source/Atmoos.Sphere.Benchmark/Program.cs
@@ -1,9 +1,14 @@
 using BenchmarkDotNet.Columns;
 using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Running;
+using Atmoos.Sphere.BenchmarkDotNet;
+
 using static BenchmarkDotNet.Columns.StatisticColumn;
 
 // dotnet run -c Release --project Atmoos.Sphere.Benchmark
+var assembly = typeof(Program).Assembly;
 var config = DefaultConfig.Instance.HideColumns(StdDev, Median, Kurtosis, BaselineRatioColumn.RatioStdDev);
 
-var summary = BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args, config);
+var summary = BenchmarkSwitcher.FromAssembly(assembly).Run(args, config);
+
+await assembly.Export(summary);

--- a/source/Atmoos.Sphere.Benchmark/Text/Convenience.cs
+++ b/source/Atmoos.Sphere.Benchmark/Text/Convenience.cs
@@ -1,0 +1,28 @@
+using Atmoos.Sphere.Text;
+
+namespace Atmoos.Sphere.Benchmark.Text;
+
+internal static class Convenience
+{
+    public static IEnumerable<String> Section(String line, Int32 count)
+    {
+        for (Int32 lineNumber = 0; lineNumber < count; lineNumber++) {
+            yield return line;
+        }
+    }
+
+    public static IEnumerable<String> Sections(Int32 pre, LineMark mark, IEnumerable<String> section, Int32 post)
+    {
+        foreach (var line in Section("Pre", pre)) {
+            yield return line;
+        }
+        yield return mark.ToString();
+        foreach (var line in section) {
+            yield return line;
+        }
+        yield return mark.Tag;
+        foreach (var line in Section("Post", post)) {
+            yield return line;
+        }
+    }
+}

--- a/source/Atmoos.Sphere.Benchmark/Text/InsertFileBenchmark.cs
+++ b/source/Atmoos.Sphere.Benchmark/Text/InsertFileBenchmark.cs
@@ -1,0 +1,56 @@
+using Atmoos.Sphere.Text;
+using BenchmarkDotNet.Attributes;
+
+using static Atmoos.Sphere.Benchmark.Text.Convenience;
+
+namespace Atmoos.Sphere.Benchmark.Text;
+
+[MemoryDiagnoser]
+[ShortRunJob, WarmupCount(5), IterationCount(11)]
+public class InsertFileBenchmark
+{
+    private const String testFile = "TestFile.cs";
+    private static readonly FileInfo file = new(testFile);
+    private static readonly LineMark md = LineMarks.Markdown.Code("csharp");
+    private static readonly String[] section = Section("Some Section", 241).ToArray();
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        File.WriteAllText(testFile, String.Join(Environment.NewLine, Sections(1154, md, section, 1965)));
+    }
+
+    [GlobalCleanup]
+    public void Cleanup() => File.Delete(testFile);
+
+    [Benchmark]
+    public Int32 InsertSynchronously()
+    {
+        file.InsertSection(md, section);
+        return 0;
+    }
+
+    [Benchmark(Baseline = true)]
+    public async Task<Int32> InsertAsynchronously()
+    {
+        await file.InsertSectionAsync(md, section).ConfigureAwait(false);
+        return 0;
+    }
+}
+
+/* Summary *
+
+BenchmarkDotNet v0.13.12, Arch Linux
+Intel Core i7-8565U CPU 1.80GHz (Whiskey Lake), 1 CPU, 8 logical and 4 physical cores
+.NET SDK 8.0.104
+  [Host]   : .NET 8.0.4 (8.0.424.16909), X64 RyuJIT AVX2
+  ShortRun : .NET 8.0.4 (8.0.424.16909), X64 RyuJIT AVX2
+
+Job=ShortRun  IterationCount=11  LaunchCount=1  
+WarmupCount=5  
+
+| Method               | Mean       | Error     | Ratio | Gen0   | Allocated | Alloc Ratio |
+|--------------------- |-----------:|----------:|------:|-------:|----------:|------------:|
+| InsertSynchronously  |   251.1 μs |   9.29 μs |  0.22 | 1.4648 |  126.3 KB |        0.34 |
+| InsertAsynchronously | 1,161.2 μs | 297.43 μs |  1.00 | 3.9063 | 367.51 KB |        1.00 |
+/* End */

--- a/source/Atmoos.Sphere.Benchmark/Text/InsertFileBenchmark.cs
+++ b/source/Atmoos.Sphere.Benchmark/Text/InsertFileBenchmark.cs
@@ -51,6 +51,6 @@ WarmupCount=5
 
 | Method               | Mean       | Error     | Ratio | Gen0   | Allocated | Alloc Ratio |
 |--------------------- |-----------:|----------:|------:|-------:|----------:|------------:|
-| InsertSynchronously  |   251.1 μs |   9.29 μs |  0.22 | 1.4648 |  126.3 KB |        0.34 |
-| InsertAsynchronously | 1,161.2 μs | 297.43 μs |  1.00 | 3.9063 | 367.51 KB |        1.00 |
+| InsertSynchronously  |   241.8 μs |  13.24 μs |  0.21 | 1.4648 |  126.3 KB |        0.34 |
+| InsertAsynchronously | 1,192.7 μs | 315.00 μs |  1.00 | 3.9063 | 367.42 KB |        1.00 |
 /* End */

--- a/source/Atmoos.Sphere.Benchmark/Text/InsertStreamBenchmark.cs
+++ b/source/Atmoos.Sphere.Benchmark/Text/InsertStreamBenchmark.cs
@@ -1,0 +1,101 @@
+using System.Text;
+using Atmoos.Sphere.Text;
+using BenchmarkDotNet.Attributes;
+
+using static Atmoos.Sphere.Benchmark.Text.Convenience;
+
+namespace Atmoos.Sphere.Benchmark.Text;
+
+[MemoryDiagnoser]
+[ShortRunJob]
+public class InsertStreamBenchmark
+{
+    private static readonly LineMark md = LineMarks.Markdown.Code("csharp");
+    private static readonly String longText = String.Join(Environment.NewLine, Sections(43, md, Section("Old Section", 9), 97));
+    private static readonly String[] section = Section("New Section", 13).ToArray();
+
+    private TextReader reader;
+    private TextWriter writer;
+
+    [Params(2, 4, 8)]
+    public Int32 MsDelay { get; set; }
+
+    [IterationSetup]
+    public void Setup()
+    {
+        var delay = TimeSpan.FromMilliseconds(MsDelay);
+        this.reader = new SlowReader(longText, delay);
+        this.writer = new SlowWriter(new StringBuilder(longText.Length), delay);
+    }
+
+    [Benchmark]
+    public Int32 InsertSynchronously()
+    {
+        this.reader.InsertSection(this.writer, md, section);
+        return 0;
+    }
+
+    [Benchmark(Baseline = true)]
+    public async Task<Int32> InsertAsynchronously()
+    {
+        await this.reader.InsertSectionAsync(this.writer, md, section).ConfigureAwait(false);
+        return 0;
+    }
+
+
+}
+
+file sealed class SlowReader(String s, TimeSpan delay) : StringReader(s)
+{
+    public override String ReadLine()
+    {
+        Thread.Sleep(delay);
+        return base.ReadLine();
+    }
+
+    public override async ValueTask<String> ReadLineAsync(CancellationToken token)
+    {
+        await Task.Yield();
+        Thread.Sleep(delay);
+        return await base.ReadLineAsync(token).ConfigureAwait(false);
+    }
+}
+
+file sealed class SlowWriter(StringBuilder sb, TimeSpan delay) : StringWriter(sb)
+{
+    public override void Write(String value)
+    {
+        Thread.Sleep(delay);
+        base.Write(value);
+    }
+
+    public override async Task WriteLineAsync(ReadOnlyMemory<Char> value, CancellationToken token = default)
+    {
+        await Task.Yield();
+        Thread.Sleep(delay);
+        await base.WriteLineAsync(value, token).ConfigureAwait(false);
+    }
+}
+
+/* Summary *
+
+BenchmarkDotNet v0.13.12, Arch Linux
+Intel Core i7-8565U CPU 1.80GHz (Whiskey Lake), 1 CPU, 8 logical and 4 physical cores
+.NET SDK 8.0.104
+  [Host]   : .NET 8.0.4 (8.0.424.16909), X64 RyuJIT AVX2
+  ShortRun : .NET 8.0.4 (8.0.424.16909), X64 RyuJIT AVX2
+
+Job=ShortRun  InvocationCount=1  IterationCount=3  
+LaunchCount=1  UnrollFactor=1  WarmupCount=3  
+
+| Method               | MsDelay | Mean       | Error    | Ratio | Allocated | Alloc Ratio |
+|--------------------- |-------- |-----------:|---------:|------:|----------:|------------:|
+| InsertSynchronously  | 2       | 1,016.3 ms | 45.58 ms |  1.46 |   7.42 KB |        0.14 |
+| InsertAsynchronously | 2       |   697.1 ms | 97.05 ms |  1.00 |  51.64 KB |        1.00 |
+|                      |         |            |          |       |           |             |
+| InsertSynchronously  | 4       | 1,936.4 ms | 15.03 ms |  1.45 |   7.42 KB |        0.14 |
+| InsertAsynchronously | 4       | 1,332.3 ms | 25.72 ms |  1.00 |  51.64 KB |        1.00 |
+|                      |         |            |          |       |           |             |
+| InsertSynchronously  | 8       | 3,803.9 ms | 91.07 ms |  1.46 |   7.42 KB |        0.14 |
+| InsertAsynchronously | 8       | 2,607.3 ms | 70.47 ms |  1.00 |  51.64 KB |        1.00 |
+/* End */

--- a/source/Atmoos.Sphere.Benchmark/Text/InsertStreamBenchmark.cs
+++ b/source/Atmoos.Sphere.Benchmark/Text/InsertStreamBenchmark.cs
@@ -88,14 +88,14 @@ Intel Core i7-8565U CPU 1.80GHz (Whiskey Lake), 1 CPU, 8 logical and 4 physical 
 Job=ShortRun  InvocationCount=1  IterationCount=3  
 LaunchCount=1  UnrollFactor=1  WarmupCount=3  
 
-| Method               | MsDelay | Mean       | Error    | Ratio | Allocated | Alloc Ratio |
-|--------------------- |-------- |-----------:|---------:|------:|----------:|------------:|
-| InsertSynchronously  | 2       | 1,016.3 ms | 45.58 ms |  1.46 |   7.42 KB |        0.14 |
-| InsertAsynchronously | 2       |   697.1 ms | 97.05 ms |  1.00 |  51.64 KB |        1.00 |
-|                      |         |            |          |       |           |             |
-| InsertSynchronously  | 4       | 1,936.4 ms | 15.03 ms |  1.45 |   7.42 KB |        0.14 |
-| InsertAsynchronously | 4       | 1,332.3 ms | 25.72 ms |  1.00 |  51.64 KB |        1.00 |
-|                      |         |            |          |       |           |             |
-| InsertSynchronously  | 8       | 3,803.9 ms | 91.07 ms |  1.46 |   7.42 KB |        0.14 |
-| InsertAsynchronously | 8       | 2,607.3 ms | 70.47 ms |  1.00 |  51.64 KB |        1.00 |
+| Method               | MsDelay | Mean       | Error     | Ratio | Allocated | Alloc Ratio |
+|--------------------- |-------- |-----------:|----------:|------:|----------:|------------:|
+| InsertSynchronously  | 2       | 1,038.8 ms | 210.85 ms |  1.45 |   7.42 KB |        0.14 |
+| InsertAsynchronously | 2       |   715.3 ms | 113.33 ms |  1.00 |  51.64 KB |        1.00 |
+|                      |         |            |           |       |           |             |
+| InsertSynchronously  | 4       | 1,970.1 ms |  32.81 ms |  1.46 |   7.42 KB |        0.14 |
+| InsertAsynchronously | 4       | 1,349.0 ms |  97.26 ms |  1.00 |  51.64 KB |        1.00 |
+|                      |         |            |           |       |           |             |
+| InsertSynchronously  | 8       | 4,055.1 ms | 129.72 ms |  1.46 |   7.42 KB |        0.14 |
+| InsertAsynchronously | 8       | 2,772.1 ms | 349.39 ms |  1.00 |  51.64 KB |        1.00 |
 /* End */

--- a/source/Atmoos.Sphere.BenchmarkDotNet/Atmoos.Sphere.BenchmarkDotNet.csproj
+++ b/source/Atmoos.Sphere.BenchmarkDotNet/Atmoos.Sphere.BenchmarkDotNet.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Atmoos.Sphere" Version="0.2.0" />
+    <PackageReference Include="Atmoos.Sphere" Version="0.2.1" />
     <PackageReference Include="BenchmarkDotNet" Version="0.13.12" />
   </ItemGroup>
 

--- a/source/Atmoos.Sphere.BenchmarkDotNet/Atmoos.Sphere.BenchmarkDotNet.csproj
+++ b/source/Atmoos.Sphere.BenchmarkDotNet/Atmoos.Sphere.BenchmarkDotNet.csproj
@@ -1,0 +1,11 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="../Atmoos.Sphere.Build.props" />
+  <Import Project="../Atmoos.Sphere.Pack.targets" />
+  
+  <PropertyGroup>
+    <PackageId>Atmoos.Sphere.BenchmarkDotNet</PackageId>
+    <Version>0.1.0</Version>
+    <PackageTags>benchmark, benchmarking</PackageTags>
+  </PropertyGroup>
+
+</Project>

--- a/source/Atmoos.Sphere.BenchmarkDotNet/Atmoos.Sphere.BenchmarkDotNet.csproj
+++ b/source/Atmoos.Sphere.BenchmarkDotNet/Atmoos.Sphere.BenchmarkDotNet.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Atmoos.Sphere" Version="0.2.1" />
+    <PackageReference Include="Atmoos.Sphere" Version="0.2.2" />
     <PackageReference Include="BenchmarkDotNet" Version="0.13.12" />
   </ItemGroup>
 

--- a/source/Atmoos.Sphere.BenchmarkDotNet/Atmoos.Sphere.BenchmarkDotNet.csproj
+++ b/source/Atmoos.Sphere.BenchmarkDotNet/Atmoos.Sphere.BenchmarkDotNet.csproj
@@ -8,4 +8,9 @@
     <PackageTags>benchmark, benchmarking</PackageTags>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Atmoos.Sphere" Version="0.1.0" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.12" />
+  </ItemGroup>
+
 </Project>

--- a/source/Atmoos.Sphere.BenchmarkDotNet/Atmoos.Sphere.BenchmarkDotNet.csproj
+++ b/source/Atmoos.Sphere.BenchmarkDotNet/Atmoos.Sphere.BenchmarkDotNet.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Atmoos.Sphere" Version="0.1.0" />
+    <PackageReference Include="Atmoos.Sphere" Version="0.2.0" />
     <PackageReference Include="BenchmarkDotNet" Version="0.13.12" />
   </ItemGroup>
 

--- a/source/Atmoos.Sphere.BenchmarkDotNet/Atmoos.Sphere.BenchmarkDotNet.csproj
+++ b/source/Atmoos.Sphere.BenchmarkDotNet/Atmoos.Sphere.BenchmarkDotNet.csproj
@@ -3,9 +3,10 @@
   <Import Project="../Atmoos.Sphere.Pack.targets" />
   
   <PropertyGroup>
-    <PackageId>Atmoos.Sphere.BenchmarkDotNet</PackageId>
     <Version>0.1.0</Version>
-    <PackageTags>benchmark, benchmarking</PackageTags>
+    <PackageId>Atmoos.Sphere.BenchmarkDotNet</PackageId>
+    <PackageTags>benchmark, benchmarking, export benchmark results</PackageTags>
+    <Description>Atmoos Sphere BenchmarkDotNet:Exports benchmark results into the defining benchmark source files.</Description>
   </PropertyGroup>
 
   <ItemGroup>

--- a/source/Atmoos.Sphere.BenchmarkDotNet/Export.cs
+++ b/source/Atmoos.Sphere.BenchmarkDotNet/Export.cs
@@ -1,0 +1,100 @@
+using BenchmarkDotNet.Exporters;
+using BenchmarkDotNet.Loggers;
+using BenchmarkDotNet.Reports;
+
+namespace Atmoos.Sphere.BenchmarkDotNet;
+
+public static class Exporter
+{
+    private static readonly String mark = "/* Summary *";
+    private static readonly ILogger logger = new Logger();
+
+    public static void Export(IEnumerable<Summary> summaries)
+    {
+        var sourceFiles = FindSourceFiles();
+        foreach (var summary in summaries) {
+            Export(summary, sourceFiles);
+        }
+    }
+    public static void Export(Summary summary) => Export(summary, FindSourceFiles());
+    private static void Export(Summary summary, List<FileInfo> allFiles)
+        => Export(summary, MarkdownExporter.Console, allFiles);
+    private static void Export(Summary summary, IExporter exporter, List<FileInfo> allFiles)
+    {
+        foreach (var file in exporter.ExportToFiles(summary, logger)) {
+            var name = BenchmarkName(file);
+            var fileName = $"{name}.cs";
+            Console.WriteLine($"Exporting: {name}");
+            var sourceFile = allFiles.Single(f => f.Name.EndsWith(fileName));
+            UpdateSourceFile(sourceFile, File.ReadAllText(file));
+            File.Delete(file);
+        }
+    }
+    private static void UpdateSourceFile(FileInfo source, String result)
+    {
+        var tmpFile = $"{source.FullName}.tmp";
+        try {
+            Update(source, tmpFile, result);
+        }
+        finally {
+            File.Move(tmpFile, source.FullName, overwrite: true);
+        }
+
+        static void Update(FileInfo source, String dest, String result)
+        {
+            String line;
+            using var reader = source.OpenText();
+            using var writer = File.CreateText(dest);
+            while ((line = reader.ReadLine()) != null) {
+                if (line.StartsWith(mark)) {
+                    // overwrite existing result
+                    Append(writer, result);
+                    return;
+                }
+                writer.WriteLine(line);
+            }
+            // No mark found, first time appending a result
+            writer.WriteLine();
+            Append(writer, result);
+
+            static void Append(TextWriter writer, String result)
+            {
+                writer.WriteLine(mark);
+                writer.Write(result);
+                writer.WriteLine("*/");
+            }
+        }
+    }
+
+    private static List<FileInfo> FindSourceFiles()
+    {
+        var myAssembly = typeof(Exporter).Assembly;
+        var assemblyName = myAssembly.GetName().Name;
+        var dir = new DirectoryInfo(myAssembly.Location);
+        while (!dir.Name.EndsWith(assemblyName)) {
+            var prev = dir.FullName;
+            dir = dir.Parent;
+            if (prev == dir.FullName) {
+                throw new Exception($"Failed finding source dir @ {prev}");
+            }
+        }
+        return dir.EnumerateFiles("*.cs", SearchOption.AllDirectories).ToList();
+    }
+    private static String BenchmarkName(ReadOnlySpan<Char> reportPath)
+    {
+        var index = reportPath.IndexOf('-');
+        var sourceName = reportPath[..index];
+        index = sourceName.LastIndexOf('.') + 1;
+        return new String(sourceName[index..]);
+    }
+}
+
+file sealed class Logger : ILogger
+{
+    public String Id => "ConsoleLogger";
+    public Int32 Priority => 1;
+    public void WriteLine() => Console.WriteLine();
+    public void Write(LogKind logKind, String text) => Console.Write(text);
+    public void WriteLine(LogKind logKind, String text) => Console.WriteLine(text);
+    public void Flush() { }
+}

--- a/source/Atmoos.Sphere.BenchmarkDotNet/readme.md
+++ b/source/Atmoos.Sphere.BenchmarkDotNet/readme.md
@@ -1,0 +1,7 @@
+# Atmoos.Sphere.BenchmarkDotNet
+
+This library can export your benchmark results into the corresponding benchmark source file. This is useful to keep track of the benchmarking results as your own project progresses.
+
+One scenario is to run all benchmarks before a release or major PR. Improvements and regressions will become visible in the diff.
+
+Usage examples can be found in the repo [Atmoos.Sphere.Benchmark](https://github.com/atmoos/Sphere/tree/main/source/Atmoos.Sphere.Benchmark).

--- a/source/Atmoos.Sphere.BenchmarkDotNet/readme.md
+++ b/source/Atmoos.Sphere.BenchmarkDotNet/readme.md
@@ -6,7 +6,25 @@ One scenario is to run all benchmarks before a release or major PR. Improvements
 
 For examples of this use case please see: [Atmoos.Sphere.Benchmark](https://github.com/atmoos/Sphere/tree/main/source/Atmoos.Sphere.Benchmark), where this library is used.
 
-## Example Use
+## Prepping Benchmark Source Files
+
+To mark the location into which the results should be inserted in your benchmark source files, simply add a `/* Summary *` start and `/*` end tag.
+
+For example like so in `MyBenchmark.cs`:
+
+```csharp
+public class MyBenchmark
+{
+    // Your benchmarks go here...
+}
+
+/* Summary *
+/* End */
+```
+
+The benchmark report will be inserted in-between those two tags.
+
+## Example Program.cs File
 
 A simple Program.cs file might look something like this:
 

--- a/source/Atmoos.Sphere.BenchmarkDotNet/readme.md
+++ b/source/Atmoos.Sphere.BenchmarkDotNet/readme.md
@@ -1,6 +1,6 @@
 # Atmoos.Sphere.BenchmarkDotNet
 
-This library can export your benchmark results into the corresponding benchmark source file. This is useful to keep track of the benchmarking results as your own project progresses.
+This library exports your benchmark results into the corresponding benchmark source files, which can be useful to keep track of the benchmarking results as work on the project progresses.
 
 One scenario is to run all benchmarks before a release or major PR. Improvements and regressions will become visible in the diff.
 

--- a/source/Atmoos.Sphere.BenchmarkDotNet/readme.md
+++ b/source/Atmoos.Sphere.BenchmarkDotNet/readme.md
@@ -4,4 +4,18 @@ This library can export your benchmark results into the corresponding benchmark 
 
 One scenario is to run all benchmarks before a release or major PR. Improvements and regressions will become visible in the diff.
 
-Usage examples can be found in the repo [Atmoos.Sphere.Benchmark](https://github.com/atmoos/Sphere/tree/main/source/Atmoos.Sphere.Benchmark).
+For examples of this use case please see: [Atmoos.Sphere.Benchmark](https://github.com/atmoos/Sphere/tree/main/source/Atmoos.Sphere.Benchmark), where this library is used.
+
+## Example Use
+
+A simple Program.cs file might look something like this:
+
+```csharp
+using BenchmarkDotNet.Running;
+using Atmoos.Sphere.BenchmarkDotNet;
+
+var assembly = typeof(Program).Assembly;
+
+var summary = BenchmarkSwitcher.FromAssembly(assembly).Run(args);
+await assembly.Export(summary); // this exports your results
+```

--- a/source/Atmoos.Sphere.Test/Async/ContextFlowTest.cs
+++ b/source/Atmoos.Sphere.Test/Async/ContextFlowTest.cs
@@ -72,6 +72,16 @@ public class ContextFlowTest
         Assert.Null(SynchronizationContext.Current);
     }
 
+    [Fact]
+    public async Task ContextFlow_CanHandleCompletelyAbsentSynchronisationContext()
+    {
+        SynchronizationContext.SetSynchronizationContext(null);
+        var flow = ContextFlow.Current();
+        Assert.Null(SynchronizationContext.Current);
+        await flow;
+        Assert.Null(SynchronizationContext.Current);
+    }
+
     private static async Task AsynchronousStuff()
     {
         const Int32 initial = 3;

--- a/source/Atmoos.Sphere.sln
+++ b/source/Atmoos.Sphere.sln
@@ -9,6 +9,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Atmoos.Sphere.Test", "Atmoo
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Atmoos.Sphere.Benchmark", "Atmoos.Sphere.Benchmark\Atmoos.Sphere.Benchmark.csproj", "{C32C194F-E125-421B-81DD-A287265450F7}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Atmoos.Sphere.BenchmarkDotNet", "Atmoos.Sphere.BenchmarkDotNet\Atmoos.Sphere.BenchmarkDotNet.csproj", "{1F179AC5-ECEC-4FA3-97D8-7453CB1F62E7}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -30,5 +32,9 @@ Global
 		{C32C194F-E125-421B-81DD-A287265450F7}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C32C194F-E125-421B-81DD-A287265450F7}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C32C194F-E125-421B-81DD-A287265450F7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1F179AC5-ECEC-4FA3-97D8-7453CB1F62E7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1F179AC5-ECEC-4FA3-97D8-7453CB1F62E7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1F179AC5-ECEC-4FA3-97D8-7453CB1F62E7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1F179AC5-ECEC-4FA3-97D8-7453CB1F62E7}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
Exports the benchmark summaries into the benchmark source files.

This allows keeping track of the benchmark runs directly in the benchmark source code.

Markers for the summary are

```csharp
/* Summary *
< summary is inserted here >
/*
```