### PR TITLE
Add benchmark export configuration options

### DIFF
--- a/.github/workflows/publish-sphere.benchmark-dotnet.yml
+++ b/.github/workflows/publish-sphere.benchmark-dotnet.yml
@@ -13,7 +13,7 @@ env:
   Prefix: 'sphere.benchmarkdotnet'
   Project: 'source/Atmoos.Sphere.BenchmarkDotNet/Atmoos.Sphere.BenchmarkDotNet.csproj'
   DotNetVersion: 8.0.x
-  NugetKey: ${{ secrets.CREATENEWNUGETPACKAGE }}
+  NugetKey: ${{ secrets.PUSH_NEW_SPHERE_VERSION }}
 
 jobs:
   publish:

--- a/source/Atmoos.Sphere.Benchmark/Async/OrderByCompletionBenchmark.cs
+++ b/source/Atmoos.Sphere.Benchmark/Async/OrderByCompletionBenchmark.cs
@@ -54,7 +54,7 @@ public class OrderByCompletionBenchmark
     }
 }
 
-/* Summary *
+/* Summary
 
 BenchmarkDotNet v0.13.12, Arch Linux
 Intel Core i7-8565U CPU 1.80GHz (Whiskey Lake), 1 CPU, 8 logical and 4 physical cores
@@ -81,4 +81,4 @@ InvocationCount=1  UnrollFactor=1
 | Unordered               | 1024  | 2,046.7 ms | 1.81 ms |  1.00 |    1.33 KB |       0.005 |
 | OrderedByCompletion     | 1024  | 2,045.5 ms | 3.22 ms |  1.00 |  241.63 KB |       1.000 |
 | NaiveCompletionOrdering | 1024  | 2,047.0 ms | 1.88 ms |  1.00 | 4508.52 KB |      18.659 |
-/* End */
+Summary */

--- a/source/Atmoos.Sphere.Benchmark/Text/Convenience.cs
+++ b/source/Atmoos.Sphere.Benchmark/Text/Convenience.cs
@@ -11,16 +11,16 @@ internal static class Convenience
         }
     }
 
-    public static IEnumerable<String> Sections(Int32 pre, LineMark mark, IEnumerable<String> section, Int32 post)
+    public static IEnumerable<String> Sections(Int32 pre, LineTag tag, IEnumerable<String> section, Int32 post)
     {
         foreach (var line in Section("Pre", pre)) {
             yield return line;
         }
-        yield return mark.ToString();
+        yield return tag.Start;
         foreach (var line in section) {
             yield return line;
         }
-        yield return mark.Tag;
+        yield return tag.End;
         foreach (var line in Section("Post", post)) {
             yield return line;
         }

--- a/source/Atmoos.Sphere.Benchmark/Text/InsertFileBenchmark.cs
+++ b/source/Atmoos.Sphere.Benchmark/Text/InsertFileBenchmark.cs
@@ -11,7 +11,7 @@ public class InsertFileBenchmark
 {
     private const String testFile = "TestFile.cs";
     private static readonly FileInfo file = new(testFile);
-    private static readonly LineMark md = LineMarks.Markdown.Code("csharp");
+    private static readonly LineTag md = LineTags.Markdown.Code("csharp");
     private static readonly String[] section = Section("Some Section", 241).ToArray();
 
     [GlobalSetup]
@@ -38,7 +38,7 @@ public class InsertFileBenchmark
     }
 }
 
-/* Summary *
+/* Summary
 
 BenchmarkDotNet v0.13.12, Arch Linux
 Intel Core i7-8565U CPU 1.80GHz (Whiskey Lake), 1 CPU, 8 logical and 4 physical cores
@@ -51,6 +51,6 @@ WarmupCount=5
 
 | Method               | Mean       | Error     | Ratio | Gen0   | Allocated | Alloc Ratio |
 |--------------------- |-----------:|----------:|------:|-------:|----------:|------------:|
-| InsertSynchronously  |   241.8 μs |  13.24 μs |  0.21 | 1.4648 |  126.3 KB |        0.34 |
-| InsertAsynchronously | 1,192.7 μs | 315.00 μs |  1.00 | 3.9063 | 367.42 KB |        1.00 |
-/* End */
+| InsertSynchronously  |   286.2 μs |  11.55 μs |  0.21 | 1.4648 | 126.27 KB |        0.34 |
+| InsertAsynchronously | 1,362.1 μs | 277.08 μs |  1.00 | 3.9063 | 367.65 KB |        1.00 |
+Summary */

--- a/source/Atmoos.Sphere.Benchmark/Text/InsertStreamBenchmark.cs
+++ b/source/Atmoos.Sphere.Benchmark/Text/InsertStreamBenchmark.cs
@@ -11,7 +11,7 @@ namespace Atmoos.Sphere.Benchmark.Text;
 [ShortRunJob]
 public class InsertStreamBenchmark
 {
-    private static readonly LineMark md = LineMarks.Markdown.Code("csharp");
+    private static readonly LineTag md = LineTags.Markdown.Code("csharp");
     private static readonly String longText = String.Join(Environment.NewLine, Sections(43, md, Section("Old Section", 9), 97));
     private static readonly String[] section = Section("New Section", 13).ToArray();
 
@@ -76,7 +76,7 @@ file sealed class SlowWriter(StringBuilder sb, TimeSpan delay) : StringWriter(sb
     }
 }
 
-/* Summary *
+/* Summary
 
 BenchmarkDotNet v0.13.12, Arch Linux
 Intel Core i7-8565U CPU 1.80GHz (Whiskey Lake), 1 CPU, 8 logical and 4 physical cores
@@ -100,4 +100,4 @@ LaunchCount=1  UnrollFactor=1  WarmupCount=3
 |                      |         |            |           |       |           |             |
 | InsertSynchronously  | 8       | 3,795.9 ms |  89.24 ms |  1.46 |   7.42 KB |        0.14 |
 | InsertAsynchronously | 8       | 2,602.9 ms |  63.58 ms |  1.00 |  51.64 KB |        1.00 |
-/* End */
+Summary */

--- a/source/Atmoos.Sphere.Benchmark/Text/InsertStreamBenchmark.cs
+++ b/source/Atmoos.Sphere.Benchmark/Text/InsertStreamBenchmark.cs
@@ -3,6 +3,7 @@ using Atmoos.Sphere.Text;
 using BenchmarkDotNet.Attributes;
 
 using static Atmoos.Sphere.Benchmark.Text.Convenience;
+using static Atmoos.Sphere.Benchmark.Text.InsertStreamBenchmark;
 
 namespace Atmoos.Sphere.Benchmark.Text;
 
@@ -17,7 +18,7 @@ public class InsertStreamBenchmark
     private TextReader reader;
     private TextWriter writer;
 
-    [Params(2, 4, 8)]
+    [Params(1, 2, 4, 8)]
     public Int32 MsDelay { get; set; }
 
     [IterationSetup]
@@ -29,34 +30,32 @@ public class InsertStreamBenchmark
     }
 
     [Benchmark]
-    public Int32 InsertSynchronously()
+    public void InsertSynchronously()
     {
         this.reader.InsertSection(this.writer, md, section);
-        return 0;
     }
 
     [Benchmark(Baseline = true)]
-    public async Task<Int32> InsertAsynchronously()
+    public async Task InsertAsynchronously()
     {
         await this.reader.InsertSectionAsync(this.writer, md, section).ConfigureAwait(false);
-        return 0;
     }
 
-
+    internal static void SimulateIo(TimeSpan delay) => Thread.Sleep(delay);
 }
 
 file sealed class SlowReader(String s, TimeSpan delay) : StringReader(s)
 {
     public override String ReadLine()
     {
-        Thread.Sleep(delay);
+        SimulateIo(delay);
         return base.ReadLine();
     }
 
     public override async ValueTask<String> ReadLineAsync(CancellationToken token)
     {
         await Task.Yield();
-        Thread.Sleep(delay);
+        SimulateIo(delay);
         return await base.ReadLineAsync(token).ConfigureAwait(false);
     }
 }
@@ -65,14 +64,14 @@ file sealed class SlowWriter(StringBuilder sb, TimeSpan delay) : StringWriter(sb
 {
     public override void Write(String value)
     {
-        Thread.Sleep(delay);
+        SimulateIo(delay);
         base.Write(value);
     }
 
     public override async Task WriteLineAsync(ReadOnlyMemory<Char> value, CancellationToken token = default)
     {
         await Task.Yield();
-        Thread.Sleep(delay);
+        SimulateIo(delay);
         await base.WriteLineAsync(value, token).ConfigureAwait(false);
     }
 }
@@ -90,12 +89,15 @@ LaunchCount=1  UnrollFactor=1  WarmupCount=3
 
 | Method               | MsDelay | Mean       | Error     | Ratio | Allocated | Alloc Ratio |
 |--------------------- |-------- |-----------:|----------:|------:|----------:|------------:|
-| InsertSynchronously  | 2       | 1,038.8 ms | 210.85 ms |  1.45 |   7.42 KB |        0.14 |
-| InsertAsynchronously | 2       |   715.3 ms | 113.33 ms |  1.00 |  51.64 KB |        1.00 |
+| InsertSynchronously  | 1       |   534.3 ms | 139.41 ms |  1.45 |   7.42 KB |        0.14 |
+| InsertAsynchronously | 1       |   367.6 ms |  58.39 ms |  1.00 |  51.64 KB |        1.00 |
 |                      |         |            |           |       |           |             |
-| InsertSynchronously  | 4       | 1,970.1 ms |  32.81 ms |  1.46 |   7.42 KB |        0.14 |
-| InsertAsynchronously | 4       | 1,349.0 ms |  97.26 ms |  1.00 |  51.64 KB |        1.00 |
+| InsertSynchronously  | 2       | 1,008.6 ms |  79.98 ms |  1.45 |   7.42 KB |        0.14 |
+| InsertAsynchronously | 2       |   696.4 ms |  31.52 ms |  1.00 |  51.64 KB |        1.00 |
 |                      |         |            |           |       |           |             |
-| InsertSynchronously  | 8       | 4,055.1 ms | 129.72 ms |  1.46 |   7.42 KB |        0.14 |
-| InsertAsynchronously | 8       | 2,772.1 ms | 349.39 ms |  1.00 |  51.64 KB |        1.00 |
+| InsertSynchronously  | 4       | 1,933.7 ms |  17.54 ms |  1.45 |   7.42 KB |        0.14 |
+| InsertAsynchronously | 4       | 1,329.4 ms |  45.18 ms |  1.00 |  51.64 KB |        1.00 |
+|                      |         |            |           |       |           |             |
+| InsertSynchronously  | 8       | 3,795.9 ms |  89.24 ms |  1.46 |   7.42 KB |        0.14 |
+| InsertAsynchronously | 8       | 2,602.9 ms |  63.58 ms |  1.00 |  51.64 KB |        1.00 |
 /* End */

--- a/source/Atmoos.Sphere.BenchmarkDotNet/Atmoos.Sphere.BenchmarkDotNet.csproj
+++ b/source/Atmoos.Sphere.BenchmarkDotNet/Atmoos.Sphere.BenchmarkDotNet.csproj
@@ -3,8 +3,7 @@
   <Import Project="../Atmoos.Sphere.Pack.targets" />
   
   <PropertyGroup>
-    <Version>0.1.0</Version>
-    <PackageId>Atmoos.Sphere.BenchmarkDotNet</PackageId>
+    <Version>0.1.1</Version>
     <PackageTags>benchmark, benchmarking, export benchmark results</PackageTags>
     <Description>Atmoos Sphere BenchmarkDotNet:Exports benchmark results into the defining benchmark source files.</Description>
   </PropertyGroup>

--- a/source/Atmoos.Sphere.BenchmarkDotNet/Atmoos.Sphere.BenchmarkDotNet.csproj
+++ b/source/Atmoos.Sphere.BenchmarkDotNet/Atmoos.Sphere.BenchmarkDotNet.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Atmoos.Sphere" Version="0.2.2" />
+    <PackageReference Include="Atmoos.Sphere" Version="0.3" />
     <PackageReference Include="BenchmarkDotNet" Version="0.13.12" />
   </ItemGroup>
 

--- a/source/Atmoos.Sphere.BenchmarkDotNet/Export.cs
+++ b/source/Atmoos.Sphere.BenchmarkDotNet/Export.cs
@@ -4,44 +4,52 @@ using BenchmarkDotNet.Exporters;
 using BenchmarkDotNet.Loggers;
 using BenchmarkDotNet.Reports;
 
+using static System.Environment;
+
 namespace Atmoos.Sphere.BenchmarkDotNet;
 
 public static class Exporter
 {
-    private static readonly ILogger logger = new Logger();
-    private static readonly LineMark mark = new() { Tag = "/*", Name = " Summary *" };
-
+    private static readonly ExportConfig defaultConfig = ExportConfig.Default;
     public static async Task Export(this Assembly assembly, IEnumerable<Summary> summaries)
+        => await assembly.Export(summaries, defaultConfig).ConfigureAwait(false);
+    public static async Task Export(this Assembly assembly, IEnumerable<Summary> summaries, ExportConfig config)
     {
+        var export = Task.CompletedTask;
         var sourceFiles = ExtractSources(assembly);
         foreach (var summary in summaries) {
-            await Export(summary, sourceFiles).ConfigureAwait(false);
+            await export.ConfigureAwait(false);
+            export = Export(summary, sourceFiles, config);
         }
+        await export.ConfigureAwait(false);
     }
 
-    public static Task Export(this Assembly assembly, Summary summary) => Export(summary, ExtractSources(assembly));
-    private static Task Export(Summary summary, List<FileInfo> allFiles)
-        => Export(summary, MarkdownExporter.Console, allFiles);
+    public static async Task Export(this Assembly assembly, Summary summary)
+        => await assembly.Export(summary, defaultConfig).ConfigureAwait(false);
+    public static async Task Export(this Assembly assembly, Summary summary, ExportConfig config)
+        => await Export(summary, ExtractSources(assembly), config).ConfigureAwait(false);
 
-    private static async Task Export(Summary summary, IExporter exporter, List<FileInfo> allFiles)
+    private static Task Export(Summary summary, List<FileInfo> allFiles, ExportConfig config)
+        => Export(summary, MarkdownExporter.Console, allFiles, config);
+    private static async Task Export(Summary summary, IExporter exporter, List<FileInfo> allFiles, ExportConfig config)
     {
         Task update = Task.CompletedTask;
-        foreach (var file in exporter.ExportToFiles(summary, logger).Select(f => new FileInfo(f))) {
+        foreach (var file in exporter.ExportToFiles(summary, config.Logger).Select(f => new FileInfo(f))) {
             var name = BenchmarkName(file.Name);
             var fileName = $"{name}.cs";
-            logger.WriteLine($"Exporting: {name}");
+            config.Logger.WriteInfo($"Exporting: {name}{NewLine}");
             // ToDo: This is not safe, but good enough for now.
             var sourceFile = allFiles.Single(f => f.Name.EndsWith(fileName));
             await update.ConfigureAwait(false);
-            update = UpdateSourceFile(sourceFile, file);
+            update = UpdateSourceFile(sourceFile, config.Tag, file);
         }
         await update.ConfigureAwait(false);
 
-        static async Task UpdateSourceFile(FileInfo source, FileInfo benchmarkReport)
+        static async Task UpdateSourceFile(FileInfo source, LineMark tag, FileInfo benchmarkReport)
         {
             try {
                 using var report = benchmarkReport.OpenText();
-                await source.InsertSectionAsync(mark, report.ReadLines()).ConfigureAwait(false);
+                await source.InsertSectionAsync(tag, report.ReadLines()).ConfigureAwait(false);
             }
             finally {
                 benchmarkReport.Delete();
@@ -71,19 +79,8 @@ public static class Exporter
     private static String BenchmarkName(String reportPath)
     {
         // path is:  Namespace.ClassName-report-console.md
-        var index = reportPath.IndexOf('-');
-        var sourceName = reportPath[..index];
-        index = sourceName.LastIndexOf('.') + 1;
-        return sourceName[index..];
+        var end = reportPath.IndexOf('-');
+        var start = reportPath.LastIndexOf('.', end, end) + 1;
+        return reportPath[start..end];
     }
-}
-
-file sealed class Logger : ILogger
-{
-    public String Id => "ConsoleLogger";
-    public Int32 Priority => 1;
-    public void WriteLine() => Console.WriteLine();
-    public void Write(LogKind logKind, String text) => Console.Write(text);
-    public void WriteLine(LogKind logKind, String text) => Console.WriteLine(text);
-    public void Flush() { }
 }

--- a/source/Atmoos.Sphere.BenchmarkDotNet/Export.cs
+++ b/source/Atmoos.Sphere.BenchmarkDotNet/Export.cs
@@ -45,7 +45,7 @@ public static class Exporter
         }
         await update.ConfigureAwait(false);
 
-        static async Task UpdateSourceFile(FileInfo source, LineMark tag, FileInfo benchmarkReport)
+        static async Task UpdateSourceFile(FileInfo source, LineTag tag, FileInfo benchmarkReport)
         {
             try {
                 using var report = benchmarkReport.OpenText();

--- a/source/Atmoos.Sphere.BenchmarkDotNet/ExportConfig.cs
+++ b/source/Atmoos.Sphere.BenchmarkDotNet/ExportConfig.cs
@@ -1,0 +1,12 @@
+using Atmoos.Sphere.Text;
+using BenchmarkDotNet.Loggers;
+
+namespace Atmoos.Sphere.BenchmarkDotNet;
+
+public sealed record class ExportConfig
+{
+    internal static LineMark defaultTag = new() { Tag = "/*", Name = " Summary *" };
+    public static ExportConfig Default => new();
+    public LineMark Tag { get; init; } = defaultTag;
+    public ILogger Logger { get; init; } = ConsoleLogger.Default;
+}

--- a/source/Atmoos.Sphere.BenchmarkDotNet/ExportConfig.cs
+++ b/source/Atmoos.Sphere.BenchmarkDotNet/ExportConfig.cs
@@ -5,8 +5,8 @@ namespace Atmoos.Sphere.BenchmarkDotNet;
 
 public sealed record class ExportConfig
 {
-    internal static LineMark defaultTag = new() { Tag = "/*", Name = " Summary *" };
+    internal static LineTag defaultTag = LineTags.CSharp.BlockComment("Summary");
     public static ExportConfig Default => new();
-    public LineMark Tag { get; init; } = defaultTag;
+    public LineTag Tag { get; init; } = defaultTag;
     public ILogger Logger { get; init; } = ConsoleLogger.Default;
 }

--- a/source/Atmoos.Sphere.BenchmarkDotNet/readme.md
+++ b/source/Atmoos.Sphere.BenchmarkDotNet/readme.md
@@ -6,9 +6,9 @@ One scenario is to run all benchmarks before a release or major PR. Improvements
 
 For examples of this use case please see: [Atmoos.Sphere.Benchmark](https://github.com/atmoos/Sphere/tree/main/source/Atmoos.Sphere.Benchmark), where this library is used.
 
-## Prepping Benchmark Source Files
+## Preparing Benchmark Source Files
 
-To mark the location into which the results should be inserted in your benchmark source files, simply add a `/* Summary *` start and `/*` end tag.
+To mark the location into which the results should be inserted in your benchmark source files, simply add a `/* Summary` start and `Summary */` end tag.
 
 For example like so in `MyBenchmark.cs`:
 
@@ -18,8 +18,8 @@ public class MyBenchmark
     // Your benchmarks go here...
 }
 
-/* Summary *
-/* End */
+/* Summary
+Summary */
 ```
 
 The benchmark report will be inserted in-between those two tags.
@@ -37,3 +37,7 @@ var assembly = typeof(Program).Assembly;
 var summary = BenchmarkSwitcher.FromAssembly(assembly).Run(args);
 await assembly.Export(summary); // this exports your results
 ```
+
+### Configuration
+
+The `Export` extension method has an overload which takes an [`ExportConfig`](https://github.com/atmoos/Sphere/blob/main/source/Atmoos.Sphere.BenchmarkDotNet/ExportConfig.cs) instance with which the export can be configured. This includes custom start and end tags.


### PR DESCRIPTION
- Configure the tags used to delineate insertion of the benchmark reports.
- Configure the logger used during export.