### PR TITLE
Fix markdown line tags

### DIFF
--- a/source/Atmoos.Sphere.Test/Text/LineTagTest.cs
+++ b/source/Atmoos.Sphere.Test/Text/LineTagTest.cs
@@ -33,8 +33,8 @@ public class LineTagTest
     [Fact]
     public void MarkdownCodeIsCorrect()
     {
-        var code = Markdown.Code("SomeName");
-        var expected = new LineTag { Start = "``` SomeName", End = "```" };
+        var code = Markdown.Code("zsh SomeScript");
+        var expected = new LineTag { Start = "```zsh SomeScript", End = "```" };
         Assert.Equal(expected, code);
     }
 

--- a/source/Atmoos.Sphere/Atmoos.Sphere.csproj
+++ b/source/Atmoos.Sphere/Atmoos.Sphere.csproj
@@ -3,7 +3,7 @@
   <Import Project="../Atmoos.Sphere.Pack.targets" />
   
   <PropertyGroup>
-    <Version>0.3.0</Version>
+    <Version>0.3.1</Version>
     <Description>Atmoos Sphere: Utilities, mechanisms, and extension methods.</Description>
   </PropertyGroup>
 

--- a/source/Atmoos.Sphere/Text/LineTag.cs
+++ b/source/Atmoos.Sphere/Text/LineTag.cs
@@ -17,7 +17,7 @@ public static class LineTags
         public static LineTag Header(String name) => FromName("#", name);
         public static LineTag SubHeader(String name) => FromName("##", name);
         public static LineTag SubSubHeader(String name) => FromName("###", name);
-        public static LineTag Code(String name) => FromName("```", name);
+        public static LineTag Code(String name) => new() { Start = $"```{name}", End = "```" };
     }
 
     public static class CSharp


### PR DESCRIPTION
Bug: Markdown tags where: ```` ``` lang mark```` (note the white space preceding "lang" )
Fixed to: ```` ```lang mark````