### PR TITLE
Emit export log in same style as BenchmarkDotNet

### DIFF
--- a/source/Atmoos.Sphere.Benchmark/Sync/SynchronousAwaitBenchmark.cs
+++ b/source/Atmoos.Sphere.Benchmark/Sync/SynchronousAwaitBenchmark.cs
@@ -1,0 +1,37 @@
+using Atmoos.Sphere.Sync;
+using BenchmarkDotNet.Attributes;
+
+namespace Atmoos.Sphere.Benchmark;
+
+[MemoryDiagnoser]
+[ShortRunJob, WarmupCount(5), IterationCount(9)]
+public class SynchronousAwaitBenchmark
+{
+    const ConfigureAwaitOptions continueOptions = ConfigureAwaitOptions.None;
+    private static readonly TimeSpan delay = TimeSpan.FromMilliseconds(63);
+
+    [Benchmark(Baseline = true)]
+    public async Task AsyncAwaitTaskDelay() => await Task.Delay(delay).ConfigureAwait(continueOptions);
+
+#pragma warning disable CS0618 // Type or member is obsolete
+    [Benchmark]
+    public void SyncAwaitTaskDelay() => Task.Delay(delay).Await(continueOptions);
+#pragma warning restore CS0618 // Type or member is obsolete
+}
+
+/* Summary
+
+BenchmarkDotNet v0.13.12, Arch Linux
+Intel Core i7-8565U CPU 1.80GHz (Whiskey Lake), 1 CPU, 8 logical and 4 physical cores
+.NET SDK 8.0.104
+  [Host]   : .NET 8.0.4 (8.0.424.16909), X64 RyuJIT AVX2
+  ShortRun : .NET 8.0.4 (8.0.424.16909), X64 RyuJIT AVX2
+
+Job=ShortRun  IterationCount=9  LaunchCount=1  
+WarmupCount=5  
+
+| Method              | Mean     | Error    | Ratio | Allocated | Alloc Ratio |
+|-------------------- |---------:|---------:|------:|----------:|------------:|
+| AsyncAwaitTaskDelay | 63.71 ms | 0.551 ms |  1.00 |     464 B |        1.00 |
+| SyncAwaitTaskDelay  | 63.34 ms | 0.350 ms |  1.00 |     360 B |        0.78 |
+Summary */

--- a/source/Atmoos.Sphere.BenchmarkDotNet/Atmoos.Sphere.BenchmarkDotNet.csproj
+++ b/source/Atmoos.Sphere.BenchmarkDotNet/Atmoos.Sphere.BenchmarkDotNet.csproj
@@ -3,13 +3,13 @@
   <Import Project="../Atmoos.Sphere.Pack.targets" />
   
   <PropertyGroup>
-    <Version>0.1.1</Version>
+    <Version>0.1.2</Version>
     <PackageTags>benchmark, benchmarking, export benchmark results</PackageTags>
     <Description>Atmoos Sphere BenchmarkDotNet:Exports benchmark results into the defining benchmark source files.</Description>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Atmoos.Sphere" Version="0.3" />
+    <PackageReference Include="Atmoos.Sphere" Version="0.3.*" />
     <PackageReference Include="BenchmarkDotNet" Version="0.13.12" />
   </ItemGroup>
 

--- a/source/Atmoos.Sphere.BenchmarkDotNet/Export.cs
+++ b/source/Atmoos.Sphere.BenchmarkDotNet/Export.cs
@@ -15,6 +15,8 @@ public static class Exporter
         => await assembly.Export(summaries, defaultConfig).ConfigureAwait(false);
     public static async Task Export(this Assembly assembly, IEnumerable<Summary> summaries, ExportConfig config)
     {
+        config.Logger.WriteExportPreamble(summaries.Count());
+
         var export = Task.CompletedTask;
         var sourceFiles = ExtractSources(assembly);
         foreach (var summary in summaries) {
@@ -27,7 +29,10 @@ public static class Exporter
     public static async Task Export(this Assembly assembly, Summary summary)
         => await assembly.Export(summary, defaultConfig).ConfigureAwait(false);
     public static async Task Export(this Assembly assembly, Summary summary, ExportConfig config)
-        => await Export(summary, ExtractSources(assembly), config).ConfigureAwait(false);
+    {
+        config.Logger.WriteExportPreamble();
+        await Export(summary, ExtractSources(assembly), config).ConfigureAwait(false);
+    }
 
     private static Task Export(Summary summary, List<FileInfo> allFiles, ExportConfig config)
         => Export(summary, MarkdownExporter.Console, allFiles, config);
@@ -35,9 +40,8 @@ public static class Exporter
     {
         Task update = Task.CompletedTask;
         foreach (var file in exporter.ExportToFiles(summary, config.Logger).Select(f => new FileInfo(f))) {
-            var name = BenchmarkName(file.Name);
-            var fileName = $"{name}.cs";
-            config.Logger.WriteInfo($"Exporting: {name}{NewLine}");
+            var (name, fileName) = BenchmarkName(file.Name);
+            config.Logger.WriteInfo($" -> {name}{NewLine}");
             // ToDo: This is not safe, but good enough for now.
             var sourceFile = allFiles.Single(f => f.Name.EndsWith(fileName));
             await update.ConfigureAwait(false);
@@ -76,11 +80,18 @@ public static class Exporter
     private static IEnumerable<String> FindSourceFilesIn(DirectoryInfo dir, String sourceType = "*.cs")
         => dir.EnumerateFiles(sourceType, SearchOption.AllDirectories).Select(f => f.FullName);
 
-    private static String BenchmarkName(String reportPath)
+    private static (String name, String fileName) BenchmarkName(String reportPath)
     {
         // path is:  Namespace.ClassName-report-console.md
         var end = reportPath.IndexOf('-');
         var start = reportPath.LastIndexOf('.', end, end) + 1;
-        return reportPath[start..end];
+        var name = reportPath[start..end];
+        return (name, $"{name}.cs");
+    }
+
+    private static void WriteExportPreamble(this ILogger logger, Int32 count = 1)
+    {
+        logger.WriteLine();
+        logger.WriteLineHeader($"// * Export to {(count <= 1 ? "source" : $"{count} sources")} *");
     }
 }


### PR DESCRIPTION
Improve the log output:
- format the log in same style as BenchmarkDotNet
- Emit error when source file for a benchmark cannot be found.